### PR TITLE
Disable overly eager unit tests

### DIFF
--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -16,5 +16,5 @@ test_that("lawn_count works", {
 test_that("count fails correctly", {
   expect_error(lawn_count(), "argument \"polygons\" is missing, with no default")
   expect_error(lawn_count(polygons = ply, points = 4), "Cannot read property")
-  expect_error(lawn_count(polygons = ply, points = pts, NULL), "ReferenceError: NA is not defined")
+  # expect_error(lawn_count(polygons = ply, points = pts, NULL), "ReferenceError: NA is not defined")
 })

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -27,7 +27,7 @@ test_that("n parameter works as expected", {
 
 test_that("lawn_sample fails correctly", {
   # missing arguments
-  expect_error(lawn_sample(), "NA is not defined")
+  # expect_error(lawn_sample(), "NA is not defined")
   # n of negative number gives back no data
   expect_equal(length(lawn_sample(dat, -1)$features), 0)
   # n of character string errors


### PR DESCRIPTION
Latest version of V8 fixes a small bug which caused a cryptic error message when evaluating nothing:

```r
ctx <- V8::v8()
ctx$eval(character(0))
## error: "ReferenceError: NA is not defined"
```

The new version coerces input to a string so it becomes `ctx$eval("")` which evaluates to null. However `lawn` has a unit test that specifically tests for the old error message. This PR disables that test.